### PR TITLE
Remove onClick triggering onGestureStart in Control component

### DIFF
--- a/src/Control.tsx
+++ b/src/Control.tsx
@@ -85,7 +85,6 @@ export function Control(props: ControlProps) {
           {...divProps}
           onMouseDown={onGestureStart}
           onTouchStart={onGestureStart}
-          onClick={onGestureStart}>
           {props.children}
         </div>
       }


### PR DESCRIPTION
Having the onClick event fire the onGestureStart handler leads to unexpected behaviour. When just clicking the knob without moving the mouse in between, onGestureStart gets fired twice and onGestureEnd only once. I'd suggest removing the onClick to get the expected result, unless there is some other reason to keep it i am not aware of?